### PR TITLE
fix warp in directory issue

### DIFF
--- a/shell_godownloader.go
+++ b/shell_godownloader.go
@@ -81,7 +81,7 @@ execute() {
   http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
   http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
   hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
-  {{- if .Archive.WrapInDirectory }}
+  {{- if eq .Archive.WrapInDirectory "true" }}
   srcdir="${tmpdir}/${NAME}"
   rm -rf "${srcdir}"
   {{- else }}


### PR DESCRIPTION

**Describe the pull request**

## before fix: 
when warp in directory is true, it will generate ` srcdir="${tmpdir}/${NAME}" rm -rf "${srcdir}"` when warp in directory is false, it will also generate ` srcdir="${tmpdir}/${NAME}" rm -rf "${srcdir}"`
